### PR TITLE
Fix build configuration for scikit-build 0.17

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.20python3.8.____cpython:
-        CONFIG: linux_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.20python3.9.____cpython:
-        CONFIG: linux_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.21python3.10.____cpython:
         CONFIG: linux_64_numpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.21python3.8.____cpython:
+        CONFIG: linux_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.21python3.9.____cpython:
+        CONFIG: linux_64_numpy1.21python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.23python3.11.____cpython:

--- a/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.10.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libblas:
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.10.* *_cpython
+spdlog:
+- '1.11'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.8.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libblas:
@@ -15,13 +15,15 @@ libblas:
 liblapack:
 - 3.9 *netlib
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
+spdlog:
+- '1.11'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.9.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libblas:
@@ -15,13 +15,15 @@ libblas:
 liblapack:
 - 3.9 *netlib
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
+spdlog:
+- '1.11'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libblas:
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.11.* *_cpython
+spdlog:
+- '1.11'
 target_platform:
 - linux-64
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1be397975ae9a9358217f9613501a5fcc1f187f5a820386d3c26b84f671ac7b3
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: CMAKE_GENERATOR="Ninja" {{ PYTHON }} -m pip install . -vv
   # Skip Windows build until qiskit-terra has a Windows build
   # Skip macOS build until https://github.com/Qiskit/qiskit-aer/issues/1689 is addressed
   skip: true  # [win or osx]
@@ -18,7 +18,6 @@ build:
   script_env:
     - DISABLE_DEPENDENCY_INSTALL=ON
     - DISABLE_CONAN=ON
-    - SKBUILD_CONFIGURE_OPTIONS="-GNinja"
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,8 @@ test:
     - ipython
     - matplotlib-base
     - pip
+    # Pin qiskit-terra for now because its deprecation warnings fail the tests for aer less than 0.12.1
+    - qiskit-terra <0.24
     - seaborn
     - stestr
 


### PR DESCRIPTION
Switch from setting SKBUILD_CONFIGURE_OPTIONS to CMAKE_GENERATOR and set the variable in the script invocation rather than in script_env.

Note the issue was not really with scikit-build 0.17 but with the conda-forge packaging of it, which stopped listing `make` as a dependency (which previous build were falling back to instead of using `ninja`).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This pulls in the configuration changes worked out in #9 without bumping the package version because it has known regressions and for now we are holding out for the next patch release.
