### PR TITLE
Add Python 3.12 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,6 +24,10 @@ jobs:
         CONFIG: linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.22python3.10.____cpython:
         CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -40,6 +44,10 @@ jobs:
         CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.10.____cpython:
         CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -54,6 +62,10 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
       linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.23python3.11.____cpython:
         CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
+      linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
       osx_64_numpy1.23python3.11.____cpython:
         CONFIG: osx_64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.26python3.12.____cpython:
+        CONFIG: osx_64_numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.22python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -31,6 +34,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.23python3.11.____cpython:
         CONFIG: osx_arm64_numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.26python3.12.____cpython:
+        CONFIG: osx_arm64_numpy1.26python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,9 @@ jobs:
       win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.23python3.11.____cpython:
         CONFIG: win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.26python3.12.____cpython:
+        CONFIG: win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,40 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.12'
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
+- - python
+  - numpy

--- a/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,40 @@
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.0'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.12'
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
+- - python
+  - numpy

--- a/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,40 @@
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '11.8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.8
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.12'
+target_platform:
+- linux-64
+zip_keys:
+- - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
+- - python
+  - numpy

--- a/.ci_support/migrations/python312.yaml
+++ b/.ci_support/migrations/python312.yaml
@@ -1,0 +1,38 @@
+migrator_ts: 1695046563
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 30
+    max_solver_attempts: 6  # this will make the bot retry "not solvable" stuff 6 times
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+
+python:
+  - 3.12.* *_cpython
+# additional entries to add for zip_keys
+numpy:
+  - 1.26
+python_impl:
+  - cpython

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.12'
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+llvm_openmp:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.12'
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.26python3.12.____cpython.yaml
@@ -1,0 +1,31 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- vs2019
+libblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+numpy:
+- '1.26'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+spdlog:
+- '1.12'
+target_platform:
+- win-64
+zip_keys:
+- - cuda_compiler
+  - cuda_compiler_version
+- - python
+  - numpy

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version12numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
@@ -80,6 +87,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version11numpy1.26python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -111,6 +125,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
@@ -136,6 +157,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -167,6 +195,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
@@ -192,6 +227,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=18698&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qiskit-aer-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cuda_compilerNonecuda_compiler_versionNonenumpy1.26python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,6 +102,7 @@ test:
     - stestr run -E test_save_statevector_for_qasm3_circuit  # [not linux and build_platform == target_platform]
   requires:
     - ddt
+    - cvxpy
     - ipython
     - matplotlib-base
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,12 +96,16 @@ test:
     - export CUDA_STUB="$PREFIX/lib/stubs/libcuda.so"  # [linux and (cuda_compiler_version or "").startswith("12")]
     - LD_PRELOAD="$CUDA_STUB" python -c "import qiskit_aer"  # [linux]
     - python -c "import qiskit_aer"                          # [not linux and build_platform == target_platform]
-    # Ignore tests that require qiskit_qasm3_import which is not packaged in conda-forge by using `-E test_save_statevector_for qasm3_circuit`
-    - stestr run -E test_save_statevector_for_qasm3_circuit  # [linux and cuda_compiler_version == "None"]
-    - LD_PRELOAD="$CUDA_STUB" stestr run -E 'test_save_statevector_for_qasm3_circuit|_GPU'  # [linux and cuda_compiler_version != "None"]
-    - stestr run -E test_save_statevector_for_qasm3_circuit  # [not linux and build_platform == target_platform]
+    # Ignore tests that require qiskit_qasm3_import which is not packaged in
+    # conda-forge by using `-E test_save_statevector_for_qasm3_circuit`
+    #
+    # Ignore TestNoiseTransformer as a workaround until
+    # https://github.com/testing-cabal/testtools/pull/371 is released
+    #
+    # Ignore _GPU tests for CUDA builds because the environment does not have a GPU
+    - stestr run -E 'test_save_statevector_for_qasm3_circuit|TestNoiseTransformer'  # [build_platform == target_platform and cuda_compiler_version == "None"]
+    - LD_PRELOAD="$CUDA_STUB" stestr run -E 'test_save_statevector_for_qasm3_circuit|TestNoiseTransformer|_GPU'  # [linux and cuda_compiler_version != "None"]
   requires:
-    - python <3.12.1  # Workaround until https://github.com/testing-cabal/testtools/pull/371 is released
     - ddt
     - ipython
     - matplotlib-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ test:
     # https://github.com/testing-cabal/testtools/pull/371 is released
     #
     # Ignore _GPU tests for CUDA builds because the environment does not have a GPU
-    - stestr run -E 'test_save_statevector_for_qasm3_circuit|TestNoiseTransformer'  # [build_platform == target_platform and cuda_compiler_version == "None"]
+    - stestr run -E "test_save_statevector_for_qasm3_circuit|TestNoiseTransformer"  # [build_platform == target_platform and cuda_compiler_version == "None"]
     - LD_PRELOAD="$CUDA_STUB" stestr run -E 'test_save_statevector_for_qasm3_circuit|TestNoiseTransformer|_GPU'  # [linux and cuda_compiler_version != "None"]
   requires:
     - ddt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,9 +101,8 @@ test:
     - LD_PRELOAD="$CUDA_STUB" stestr run -E 'test_save_statevector_for_qasm3_circuit|_GPU'  # [linux and cuda_compiler_version != "None"]
     - stestr run -E test_save_statevector_for_qasm3_circuit  # [not linux and build_platform == target_platform]
   requires:
+    - python <3.12.1  # Workaround until https://github.com/testing-cabal/testtools/pull/371 is released
     - ddt
-    - cvxpy
-    - pybind11  # Temporary workaround for https://github.com/cvxpy/cvxpy/issues/2330
     - ipython
     - matplotlib-base
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,6 +103,7 @@ test:
   requires:
     - ddt
     - cvxpy
+    - pybind11  # Temporary workaround for https://github.com/cvxpy/cvxpy/issues/2330
     - ipython
     - matplotlib-base
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qiskit-aer" %}
 {% set version = "0.13.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}


### PR DESCRIPTION
The migrator seems confused by another package from a split feedstock that also produces non-Python packages that qiskit-aer depends on not having Python 3.12 builds yet, so this is a manual migration attempt.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
