### PR TITLE
Add nomkl to host dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qiskit-aer" %}
 {% set version = "0.17" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}
@@ -61,6 +61,11 @@ requirements:
     # https://github.com/Qiskit/qiskit-aer/issues/1742 where problems were
     # reported with 3.10.3
     - nlohmann_json <=3.10.2
+    # In early 2025, mkl started getting installed randomly on Linux about 50%
+    # of the time. When this happens the build seems to link to it but not add
+    # it to the run exports. Maybe mkl builds could work but we have been doing
+    # fine without them so just make sure they do not happen for now.
+    - nomkl
     - pip
     - python
     - pybind11 >=2.12.0  # This constraint is for CUDA 12 and numpy 2.0, not for qiskit-aer


### PR DESCRIPTION
This will hopefully prevent the random build failures from mkl getting installed and not handled correctly recently.

mkl has been getting installed into the host environment about 50% of the time on Linux and leading to an overlinking error. I think that means that the build is linking against mkl but not adding it to the run exports, but I didn't test. Maybe an mkl build could work but for now just block mkl since we had been doing fine building a non-mkl variant of the package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
